### PR TITLE
Fix errors found by fuzzing

### DIFF
--- a/url.cpp
+++ b/url.cpp
@@ -309,6 +309,9 @@ std::string normalize_IPv6(const char *s, const char *e) {
     i = nfields;
     nfields=(ipv4_b)?6:8;
     if (i<nfields) {
+        if (i<null_pos) {
+            throw Url::parse_error("IPv6 ["+std::string(s,e-s)+"] is invalid");
+        }
         size_t last=nfields;
         if (i!=null_pos)
             do fields[--last]=fields[--i]; while (i!=null_pos);

--- a/url.cpp
+++ b/url.cpp
@@ -266,7 +266,8 @@ std::string normalize_IPv6(const char *s, const char *e) {
         return std::string(s,e-s);
 
     // Split IPv6 at colons
-    const char *p=s, *tokens[10];
+    const size_t token_size = 10;
+    const char *p=s, *tokens[token_size];
     if (*p==':')
         ++p;
     if (e[-1]==':')
@@ -275,6 +276,9 @@ std::string normalize_IPv6(const char *s, const char *e) {
     size_t i=0;
     while (p!=e) {
         if (*p++==':') {
+            if (i+1 >= token_size) {
+                throw Url::parse_error("IPv6 ["+std::string(s,e-s)+"] is invalid");
+            }
             tokens[i++]=b;
             b=p;
         }

--- a/url.cpp
+++ b/url.cpp
@@ -297,13 +297,17 @@ std::string normalize_IPv6(const char *s, const char *e) {
     }
 
     // Decode the fields
-    std::uint16_t fields[8];
+    const size_t fields_size = 8;
+    std::uint16_t fields[fields_size];
     size_t null_pos=8, null_len=0, nfields=0;
     for(size_t i=0; i<ntokens; ++i) {
         const char *p=tokens[i];
         if (p==tokens[i+1] || *p==':')
             null_pos=i;
         else {
+            if (nfields >= fields_size) {
+                throw Url::parse_error("IPv6 ["+std::string(s,e-s)+"] is invalid");
+            }
             std::uint16_t field=get_hex_digit(*p++);
             while (p!=tokens[i+1] && *p!=':')
                 field=(field<<4)|get_hex_digit(*p++);


### PR DESCRIPTION
I added the following libfuzzer target and ran into some issues. This branch contains all the fixes.

```cxx
extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
  try {
    Url url{std::string{reinterpret_cast<const char*>(data), size}};
    (void)url.port();
  } catch (Url::parse_error&) {

  }
  return 0;
}
```