### PR TITLE
Fix userinfo parsing

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -7,6 +7,17 @@
 
 using namespace std;
 
+#define test_parse(str, m, expect) {\
+    try {\
+        Url url(str);\
+        if(url.m()!=expect)\
+            cout << "FAILED: ('" << str << "') -> "#m"('" << url.m() << "') (expect " << expect << ")" << endl;\
+        else\
+            cout << "PASSED: ('" << str << "') -> "#m"('" << url.m() << "')" << endl;\
+    } catch(std::exception &e) {\
+        cout << "FAILED: ('" << str << "') -> \"" << e.what() << "\" (expect " << expect << ")" << endl;\
+    }\
+}
 
 
 #define test_valid(m1,str,m2,expect,ip_v) {\
@@ -56,6 +67,7 @@ void test_all_valid() {
     cout << "------------------------------------------------------" << endl;
     test_valid(user_info,"",user_info,"",-1);
     test_valid(user_info,"user:passwd",user_info,"user:passwd",-1);
+    test_parse("http://user:pa%24%24wd@www.example.com",user_info,"user:pa$$wd");
 
     cout << "------------------------------------------------------" << endl;
     cout << "Test host" << endl;

--- a/url.cpp
+++ b/url.cpp
@@ -727,7 +727,7 @@ void Url::parse_url() const {
             p=find_char(b, ea, '@');
             // get user info if any
             if (p!=ea) {
-                if (!is_chars(b, p, 0x05))
+                if (!is_chars(b, p, 0x25))
                     throw Url::parse_error("User info in '"+std::string(s,e-s)+"' is invalid");
                 user_b=b;
                 user_e=p;


### PR DESCRIPTION
Percent encoding is allowed in the `userinfo` according to RFC-3986 [1], 
and indeed this code already url-decoded the `userinfo`.  So it's incorrect
to reject percentage signs inside the `userinfo` field.

[1]: https://datatracker.ietf.org/doc/html/rfc3986