### PR TITLE
refactor cmake, add installation target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,21 @@
 cmake_minimum_required(VERSION 3.4)
-project(CxxUrl)
+project(CxxUrl
+    VERSION 0.3.0
+)
 
-set(CMAKE_CXX_STANDARD 11)
 
-add_definitions(-D_GNU_SOURCE -Wall -Wextra)
+#*********************************************************
+# GLOBAL OPTIONS - you can change those
+# Note: that options are cached, so in order to reavaluate options
+# specified via CLI you need to remove the cmake folder
+#*********************************************************
+
+option(ENABLE_INSTALL "Flag to indicate if the install target should be available" ON)
+
+if(${PROJECT_IS_TOP_LEVEL})
+    # This will be executed if the current project is top level
+    add_definitions(-D_GNU_SOURCE -Wall -Wextra)
+endif()
 
 #*********************************************************
 # determine platform
@@ -14,7 +26,6 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     set(PLATFORM LINUX)
     if (DEFINED ${ANDROID_PLATFORM})
         set(PLATFORM ANDROID)
-        add_definitions(-DANDROID_PLATFORM)
     endif()
 elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
     set(PLATFORM MAC_OS)
@@ -22,10 +33,18 @@ elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     set(PLATFORM WINDOWS)
 elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Android")
     set(PLATFORM ANDROID)
-    add_definitions(-DANDROID_PLATFORM)
 endif()
 
-message("Platform: " ${CMAKE_SYSTEM_NAME} "-" ${PLATFORM})
+message(DEBUG "Platform: " ${CMAKE_SYSTEM_NAME} "-" ${PLATFORM})
+
+#*********************************************************
+# Project Settings (no need to edit those)
+#*********************************************************
+
+include(GNUInstallDirs) # for CMAKE_INSTALL_FULL_INCLUDEDIR
+set(INSTALL_HEADER_INCLUDE_DIR "${CMAKE_INSTALL_FULL_INCLUDEDIR}/${PROJECT_NAME}")
+set(NAMESPACE chmike)
+set(TARGET_NAME ${PROJECT_NAME})
 
 set(HEADERS
         ${CMAKE_CURRENT_SOURCE_DIR}/url.hpp
@@ -35,6 +54,74 @@ set(SOURCES
         ${HEADERS}
         ${CMAKE_CURRENT_SOURCE_DIR}/url.cpp)
 
-add_library(CxxUrl SHARED ${SOURCES})
-set_target_properties(CxxUrl PROPERTIES SOVERSION 1)
-set_target_properties(CxxUrl PROPERTIES PUBLIC_HEADER url.hpp)
+add_library(${TARGET_NAME} SHARED ${SOURCES})
+add_library(${NAMESPACE}::${TARGET_NAME} ALIAS ${TARGET_NAME})
+
+set_target_properties(${TARGET_NAME} PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED ON)
+set_target_properties(${TARGET_NAME} PROPERTIES SOVERSION 1)
+set_target_properties(${TARGET_NAME} PROPERTIES PUBLIC_HEADER "${HEADERS}")
+
+if(${PLATFORM} STREQUAL ANDROID)
+    message(INFO "${PROJECT_NAME} Platform Android detected")
+    target_compile_definitions(${TARGET_NAME} PUBLIC ANDROID_PLATFORM)
+endif()
+
+# The following tells CMake to propagate the correct include directory if this project is linked via target_link_libraries
+target_include_directories(CxxUrl
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${INSTALL_HEADER_INCLUDE_DIR}>
+)
+
+if(${ENABLE_INSTALL})
+    set(PACKAGE_NAME ${PROJECT_NAME}) # the package name is what you write in find_package
+    set(TARGETS_FILE_NAME     "${PACKAGE_NAME}Targets.cmake")
+    set(TARGETS_FILE_PATH     "${CMAKE_CURRENT_BINARY_DIR}/${TARGETS_FILE_NAME}")
+    set(VERSION_FILE_PATH     "${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}ConfigVersion.cmake")
+    set(CONFIG_FILE_PATH      "${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}Config.cmake")
+    set(PACKAGE_CONFIG_IN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/CxxUrlConfig.cmake.in")
+
+    install(
+        TARGETS ${TARGET_NAME}
+        EXPORT ${PACKAGE_NAME} DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}
+        PUBLIC_HEADER DESTINATION ${INSTALL_HEADER_INCLUDE_DIR}
+    )
+
+    install(
+        EXPORT ${PACKAGE_NAME}
+        FILE ${TARGETS_FILE_NAME}
+        NAMESPACE "${NAMESPACE}::"
+        DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PACKAGE_NAME}"
+    )
+
+    include(CMakePackageConfigHelpers)
+    configure_package_config_file(
+        "${PACKAGE_CONFIG_IN_FILE}"
+        ${CONFIG_FILE_PATH}
+        INSTALL_DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PACKAGE_NAME}"
+    )
+
+    message(INFO "\tExpanding CMAKE_PREFIX_PATH to include package build dir") # this enables find_package after add_subdirectory
+    if(${PROJECT_IS_TOP_LEVEL})
+        set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${CMAKE_CURRENT_BINARY_DIR}")
+    else()
+        set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${CMAKE_CURRENT_BINARY_DIR}" PARENT_SCOPE)
+    endif()
+
+    write_basic_package_version_file(
+      ${VERSION_FILE_PATH}
+      VERSION ${PROJECT_VERSION}
+      COMPATIBILITY SameMinorVersion # TODO: once 1.0.0 is reached, change to SameMajorVersion
+    )
+
+    install(
+        FILES ${VERSION_FILE_PATH} ${CONFIG_FILE_PATH}
+        DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PACKAGE_NAME}"
+    )
+
+    export(
+        TARGETS ${TARGET_NAME}
+        NAMESPACE "${NAMESPACE}::"
+        FILE "${TARGETS_FILE_PATH}"
+    )
+endif()

--- a/README.md
+++ b/README.md
@@ -1,5 +1,25 @@
 # A simple C++ URL class
 
+## Usage
+
+### CMake
+
+If you are developing your project with CMake you can include this library with the `find_package` mechanism of CMake.
+First, either run `make install` or include this project via `add_subdirectory`.
+Afterwards, you can link to this lib like so:
+
+```CMake
+cmake_minimum_required(VERSION 3.4)
+
+project(example_find_package)
+
+find_package(CxxUrl REQUIRED)
+
+add_executable(${PROJECT_NAME} main.cpp)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC chmike::CxxUrl)
+```
+
 ### The `Url` object API
 `Url` is a C++ URL handling class with a very simple API. It's use is straightforward.
 

--- a/cmake/CxxUrlConfig.cmake.in
+++ b/cmake/CxxUrlConfig.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+if(NOT TARGET @INSTALL_TEST_TARGET@)
+  include ("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_FILE_NAME@")
+endif()
+
+check_required_components(@PACKAGE_NAME@)


### PR DESCRIPTION
Currently, it is not possible to install this project globally on a system. This commit does two things:

- It changes global compilation settings like language level to be target specific
- It adds an installation target that allows other users to install the package globally on their systems

When this lib is installed, users can find it in their CMake projects via find_package and link it via target_link_library.